### PR TITLE
[FIX] change message when too many or too less arguments are given

### DIFF
--- a/run_exp.py
+++ b/run_exp.py
@@ -20,7 +20,7 @@ torch.manual_seed(seed)
 
 # Get the path to the configuration file from the command-line arguments
 if len(sys.argv) != 2:
-    print("Usage: python3 experiment.py CONFIG_FILE_PATH")
+    print("Usage: python3 ./run_exp.py CONFIG_FILE_PATH")
     sys.exit(1)
 config_file_path = sys.argv[1]
 


### PR DESCRIPTION
Just a minor change on the error of usage given when too many or too less arguments are passed to "python3 ./run_exp.py".