### PR TITLE
[FIX] recursive multi steps strategy

### DIFF
--- a/src/utils_training.py
+++ b/src/utils_training.py
@@ -56,7 +56,7 @@ def train_model(model, train_loader, val_loader, model_path, num_epochs = 200, r
 
             for i in range(1, horizon_size):
 
-                outputs = model(torch.cat((inputs[:, i:, :], final_output[:, -1, :].unsqueeze(1)), dim=1))
+                outputs = model(torch.cat((inputs[:, i:, :], final_output), dim=1))
                 final_output = torch.cat([final_output, outputs.unsqueeze(1)], dim=1)
 
             optimizer.zero_grad()
@@ -119,7 +119,7 @@ def validate_model(val_loader, model, optimizer, criterion, valid_losses, model_
 
             for i in range(1, horizon_size):
 
-                outputs = model(torch.cat((inputs[:, i:, :], final_output[:, -1, :].unsqueeze(1)), dim=1))
+                outputs = model(torch.cat((inputs[:, i:, :], final_output), dim=1))
                 final_output = torch.cat([final_output, outputs.unsqueeze(1)], dim=1)
 
             optimizer.zero_grad()
@@ -201,7 +201,7 @@ def testmodel_recursive(best_model, test_loader, path=None, meanstd_dict =None, 
             outputs = best_model(inputs.double())
             final_output = torch.cat([final_output, outputs.unsqueeze(1)], dim=1)
             for i in range(1, horizon_size):
-                outputs = best_model(torch.cat((inputs[:, i:, :], final_output[:, -1, :].unsqueeze(1)), dim=1))
+                outputs = best_model(torch.cat((inputs[:, i:, :], final_output), dim=1))
                 final_output = torch.cat([final_output, outputs.unsqueeze(1)], dim=1)
             # loss = criterion(final_output, targets)
             # test_loss += loss.item()


### PR DESCRIPTION
A fix was made to the recursive multi-step strategy because it wasn’t working as intended. Before the fix, only the last prediction was used to compute the next prediction, instead of using all previous predictions. 
For example, suppose we have an input of [1, 2, 3, 4] and a windows_size of 4. Then, we use 1, 2, 3, and 4 to predict the 5th value. Then, to predict the 6th we use 2, 3, 4, and the 5th value predicted before. However, there was a problem when predicting the 7th value. Instead of using 3, 4 and the two last values predicted (5th and 6th values) to predict the 7th value as intended, the previous version only used 3, 4, and 6 because it only used the last prediction. This is not how the recursive multi-step strategy is supposed to work.